### PR TITLE
move http port into config and better handling of directories

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -1,3 +1,5 @@
 ## list of directories which contain things we might want to play
 root = ["/home/inaimathi/videos",
         "/home/inaimathi/music"]
+## what port do you want the HTTP server to listen on
+httpport = 8080

--- a/main.py
+++ b/main.py
@@ -54,5 +54,5 @@ settings = {
 app = tornado.web.Application(urls, **settings)
 
 if __name__ == "__main__":
-    app.listen(8080)
+    app.listen(httpport)
     tornado.ioloop.IOLoop.instance().start()

--- a/util.py
+++ b/util.py
@@ -32,10 +32,11 @@ def nameToTitle(filename):
     return re.sub(" [ _-]+", " - ", re.sub("[-_]", " ", os.path.basename(filename).title()))
 
 def entryToDict(entry):
-    name, ext = os.path.splitext(entry)
-    if ext == '':
+    if os.path.isdir(entry):
+        name = entry
         ext = "directory"
     else:
+        name, ext = os.path.splitext(entry)
         ext = ext[1:]
     return {'path': entry, 'type': ext, 'name': nameToTitle(name), 'buttons': True}
 

--- a/util.py
+++ b/util.py
@@ -28,8 +28,10 @@ def isInRoot(entry):
             return True
     return False
 
+resub = re.compile("[-_ ]+")
 def nameToTitle(filename):
-    return re.sub(" [ _-]+", " - ", re.sub("[-_]", " ", os.path.basename(filename).title()))
+    name = os.path.basename(filename)
+    return resub.sub(" ", name)
 
 def entryToDict(entry):
     if os.path.isdir(entry):


### PR DESCRIPTION
I've moved the HTTP server port over to the `conf.py` as I wanted to change it and this seems like a better place…

Also, improved handling of directories.  Previously this was based on whether the name included a dot, and I have several directories that contain a "." which broke previously.  I've also changed the way filename is changed into a "Title", regex is pre-compiled as it's going to be called quite a few times, also unified the two regexes into one.  Removed the call to string.title() as I've got a few directories with abbreviations in and this breaks them.
